### PR TITLE
Fixed the main menu dupe bug when exiting from page menu

### DIFF
--- a/src/main/java/UI/MainUI.java
+++ b/src/main/java/UI/MainUI.java
@@ -184,7 +184,8 @@ public class MainUI extends JFrame {
             pickFileButton.setEnabled(false);
             closeButton.setEnabled(false);
 
-            new PageUI(pages, darkMode, translatePage).setVisible(true);
+            this.setVisible(false);
+            new PageUI(pages, darkMode, translatePage, this).setVisible(true);
         });
 
         closeButton.addActionListener(e -> dispose());

--- a/src/main/java/UI/PageUI.java
+++ b/src/main/java/UI/PageUI.java
@@ -18,11 +18,13 @@ public class PageUI extends JFrame {
     private JEditorPane content;
     private JButton backButton;
     private boolean darkMode;
+    private JFrame parentFrame;
 
-    public PageUI(List<Page> pageSet, boolean darkMode, TranslatePage translatePage) {
+    public PageUI(List<Page> pageSet, boolean darkMode, TranslatePage translatePage, JFrame parentFrame) {
         this.pages = pageSet;
         this.currentPage = 0;
         this.darkMode = darkMode;
+        this.parentFrame = parentFrame;
 
         setTitle("Page View");
         setSize(450, 700);
@@ -71,7 +73,7 @@ public class PageUI extends JFrame {
 
         backButton.addActionListener(e -> {
             dispose();
-            new MainUI(ConfigDataRetriever.get("api_key"));
+            parentFrame.setVisible(true);
         });
         // Apply dark mode theme to buttons and panel
         if (darkMode) {


### PR DESCRIPTION
The main menu no longer stays and duplicates itself now after clicking the close button on PageUI